### PR TITLE
Enable support for https

### DIFF
--- a/lib/google-webfonts/helper.rb
+++ b/lib/google-webfonts/helper.rb
@@ -84,12 +84,16 @@ module Google
         
         # the fonts are separated by pipes
         family = fonts.join("|")
-        
+
+        # generate https links if we are an https site
+        request.ssl? ? request_method = "https" : request_method = "http"
+
         # return the link tag
         tag 'link', {
             :rel  => :stylesheet,
             :type => Mime::CSS,
             :href => "http://fonts.googleapis.com/css?family=#{family}"
+            :href => "#{request_method}://fonts.googleapis.com/css?family=#{family}"
           },
           false,
           false


### PR DESCRIPTION
Hello,

I was getting mixed content error messages, specifically in Chrome when accessing my site over HTTPS. I've updated the helper to detect the presence of https and generate the link to Google using this if required.

Marc
