### PR TITLE
Fix https detection together with specs

### DIFF
--- a/google-webfonts.gemspec
+++ b/google-webfonts.gemspec
@@ -4,11 +4,11 @@ require File.expand_path('../lib/google-webfonts/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ["Travis Haynes"]
   gem.email         = ["travis.j.haynes@gmail.com"]
-  
+
   gem.description   = "Google Webfonts helper for Rails or Sinatra applications."
   gem.summary       = %q{Provides a helper for using Google Webfonts in Rails or
 Sinatra, although it can be used outside of those frameworks as well.}
-  
+
   gem.homepage      = "https://github.com/travishaynes/Google-Webfonts-Helper"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
@@ -17,10 +17,10 @@ Sinatra, although it can be used outside of those frameworks as well.}
   gem.name          = "google-webfonts"
   gem.require_paths = ["lib"]
   gem.version       = Google::Webfonts::VERSION
-  
+
   gem.add_runtime_dependency      'actionpack',   '>= 3.0.0'
-  
-  gem.add_development_dependency  'rspec',        '~> 2.8.0'
+
+  gem.add_development_dependency  'rspec-rails',  '~> 2.0'
   gem.add_development_dependency  'yard-tomdoc',  '~> 0.4.0'
   gem.add_development_dependency  'sinatra',      '~> 1.3.2'
 end

--- a/lib/google-webfonts/helper.rb
+++ b/lib/google-webfonts/helper.rb
@@ -1,11 +1,11 @@
 module Google
   module Webfonts
-  
+
     # Public: Helper module that includes the google_webfonts_link_tag method.
     # This module is automatically included in your Rails view helpers.
     module Helper
       include ActionView::Helpers::TagHelper
-      
+
       # Public: Generates a Google Webfonts link tag
       # 
       # options - The font options. This can be a String, Symbol, or Hash, or
@@ -37,42 +37,42 @@ module Google
       # Raises ArgumentError if a size is not a String or Fixnum.
       def google_webfonts_link_tag(*options)
         raise ArgumentError, "expected at least one font" if options.empty?
-        
+
         fonts = []
-        
+
         options.each do |option|
           case option.class.to_s
           when "Symbol", "String"
             # titleize the font name
             font_name = option.to_s.titleize
-            
+
             # replace any spaces with pluses
             font_name = font_name.gsub(" ", "+")
-            
+
             # include the font
             fonts << font_name
           when "Hash"
             fonts += option.inject([]) do |result, (font_name, sizes)|
               # ensure sizes is an Array
               sizes = Array(sizes)
-              
+
               sizes.all? do |size|
                 unless size.class == Fixnum || size.class == String
                   raise ArgumentError, "expected a Fixnum or String, got a #{size.class}"
                 end
               end
-              
+
               # convert font name into a String
               font_name = font_name.to_s
-              
+
               # replace underscores with spaces
               # and titleize the font name
               font_name = font_name.gsub("_", " ")
               font_name = font_name.titleize
-              
-              # convert the spaces into pluses 
+
+              # convert the spaces into pluses
               font_name = font_name.gsub(" ", "+")
-              
+
               # return font_name:sizes where
               # sizes is a comma separated list
               result << "#{font_name}:#{sizes.join(",")}"
@@ -81,7 +81,7 @@ module Google
             raise ArgumentError, "expected a String, Symbol, or a Hash, got a #{option.class}"
           end
         end
-        
+
         # the fonts are separated by pipes
         family = fonts.join("|")
 
@@ -89,16 +89,14 @@ module Google
         request.ssl? ? request_method = "https" : request_method = "http"
 
         # return the link tag
-        tag 'link', {
-            :rel  => :stylesheet,
-            :type => Mime::CSS,
-            :href => "http://fonts.googleapis.com/css?family=#{family}"
-            :href => "#{request_method}://fonts.googleapis.com/css?family=#{family}"
-          },
-          false,
-          false
+        options = {
+          :rel  => :stylesheet,
+          :type => Mime::CSS,
+          :href => "#{request_method}://fonts.googleapis.com/css?family=#{family}"
+        }
+        tag 'link', options, false, false
       end
     end
-    
+
   end
 end

--- a/spec/google-webfonts/helper_spec.rb
+++ b/spec/google-webfonts/helper_spec.rb
@@ -1,126 +1,139 @@
 require 'spec_helper'
 
 describe Google::Webfonts::Helper do
+  include RSpec::Rails::HelperExampleGroup
   include Google::Webfonts::Helper
-  
+
   def validate(tag, family)
     # should be a link tag
     tag.should =~ /<link.*\/>/
-    
+
     # should include an href to the google webfonts api
     tag.should =~ /href="http:\/\/fonts.googleapis.com\/css\?family=/
-    
+
     # should be a stylesheet
     tag.should =~ /rel="stylesheet"/
-    
+
     # should be text/css
     tag.should =~ /type="text\/css"/
-    
+
     # should include the expected font-family
     tag.should =~ /#{family}/
   end
-  
+
   describe "#google_webfonts_link_tag" do
-    
-    context "with no arguments" do
-      it "should raise ArgumentError" do
-        expect { google_webfonts_link_tag }.to raise_error ArgumentError
+    before { helper.stub(:request).and_return(request) }
+
+    context 'when request is ssl' do
+      let(:request) { double(:request, ssl?: true) }
+
+      it 'generates a link with https' do
+        google_webfonts_link_tag(:hello).should =~ /href="https:\/\/fonts.googleapis.com\/css\?family=/
       end
     end
-    
-    context "with something other than a String, Symbol, or Hash" do
-      it "should raise ArgumentError" do
-        expect { google_webfonts_link_tag(1) }.to raise_error ArgumentError
-      end
-    end
-    
-    context "when a size is something other than a String, or Fixnum" do
-      it "should raise ArgumentError" do
-        expect { google_webfonts_link_tag(:font => [:symbol]) }.to raise_error ArgumentError
-      end
-    end
-    
-    specify "with 1 font as a String" do
-      validate google_webfonts_link_tag("hello"), "Hello"
-    end
-    
-    specify "with 1 font as a Symbol" do
-      validate google_webfonts_link_tag(:hello), "Hello"
-    end
-    
-    specify "with multiple fonts as Strings" do
-      validate google_webfonts_link_tag("hello", "world"), "Hello|World"
-    end
-    
-    specify "with multiple fonts as a combination of Strings and Symbols" do
-      validate google_webfonts_link_tag("hello", :world), "Hello|World"
-    end
-    
-    context "with a Hash and 1 font name" do
-      context "with a Symbol as the key" do
-        specify "with 1 font size" do
-          validate google_webfonts_link_tag(:hello => 100), "Hello:100"
-        end
-        
-        specify "with 2 font sizes" do
-          validate google_webfonts_link_tag(:hello => [100, 200]), "Hello:100,200"
+
+    context 'when request is not ssl' do
+      let(:request) { double(:request, ssl?: false) }
+
+      context "with no arguments" do
+        it "should raise ArgumentError" do
+          expect { google_webfonts_link_tag }.to raise_error ArgumentError
         end
       end
-      
-      context "with a String as the key" do
-        specify "with 1 font size" do
-          validate google_webfonts_link_tag("hello" => 100), "Hello:100"
-        end
-        
-        specify "with 2 font sizes" do
-          validate google_webfonts_link_tag("hello" => [100, 200]), "Hello:100,200"
+
+      context "with something other than a String, Symbol, or Hash" do
+        it "should raise ArgumentError" do
+          expect { google_webfonts_link_tag(1) }.to raise_error ArgumentError
         end
       end
-    end
-    
-    context "with a Hash and 2 font names" do
-      context "with a Symbol as the key" do
-        specify "with 1 font size" do
-          validate google_webfonts_link_tag(:hello => 100, :world => 200), "Hello:100|World:200"
-        end
-        
-        specify "with 2 font sizes" do
-          validate google_webfonts_link_tag(:hello => [100, 200], :world => [300, 400]), "Hello:100,200|World:300,400"
+
+      context "when a size is something other than a String, or Fixnum" do
+        it "should raise ArgumentError" do
+          expect { google_webfonts_link_tag(:font => [:symbol]) }.to raise_error ArgumentError
         end
       end
-      
-      context "with a String as the key" do
-        specify "with 1 font size" do
-          validate google_webfonts_link_tag("hello" => 100, "world" => 200), "Hello:100|World:200"
+
+      specify "with 1 font as a String" do
+        validate google_webfonts_link_tag("hello"), "Hello"
+      end
+
+      specify "with 1 font as a Symbol" do
+        validate google_webfonts_link_tag(:hello), "Hello"
+      end
+
+      specify "with multiple fonts as Strings" do
+        validate google_webfonts_link_tag("hello", "world"), "Hello|World"
+      end
+
+      specify "with multiple fonts as a combination of Strings and Symbols" do
+        validate google_webfonts_link_tag("hello", :world), "Hello|World"
+      end
+
+      context "with a Hash and 1 font name" do
+        context "with a Symbol as the key" do
+          specify "with 1 font size" do
+            validate google_webfonts_link_tag(:hello => 100), "Hello:100"
+          end
+
+          specify "with 2 font sizes" do
+            validate google_webfonts_link_tag(:hello => [100, 200]), "Hello:100,200"
+          end
         end
-        
-        specify "with 2 font sizes" do
-          validate google_webfonts_link_tag("hello" => [100, 200], "world" => [300, 400]), "Hello:100,200|World:300,400"
+
+        context "with a String as the key" do
+          specify "with 1 font size" do
+            validate google_webfonts_link_tag("hello" => 100), "Hello:100"
+          end
+
+          specify "with 2 font sizes" do
+            validate google_webfonts_link_tag("hello" => [100, 200]), "Hello:100,200"
+          end
         end
       end
-    end
-    
-    context "when the font name includes an underscore" do
-      it "should convert the underscore to a +" do
-        validate google_webfonts_link_tag(:droid_sans => [400, 700]), 'Droid\+Sans:400,700'
+
+      context "with a Hash and 2 font names" do
+        context "with a Symbol as the key" do
+          specify "with 1 font size" do
+            validate google_webfonts_link_tag(:hello => 100, :world => 200), "Hello:100|World:200"
+          end
+
+          specify "with 2 font sizes" do
+            validate google_webfonts_link_tag(:hello => [100, 200], :world => [300, 400]), "Hello:100,200|World:300,400"
+          end
+        end
+
+        context "with a String as the key" do
+          specify "with 1 font size" do
+            validate google_webfonts_link_tag("hello" => 100, "world" => 200), "Hello:100|World:200"
+          end
+
+          specify "with 2 font sizes" do
+            validate google_webfonts_link_tag("hello" => [100, 200], "world" => [300, 400]), "Hello:100,200|World:300,400"
+          end
+        end
       end
-    end
-    
-    context "when the font name includes a space" do
-      it "should conver the space to a +" do
-        validate google_webfonts_link_tag("Droid Sans" => [400, 700]), 'Droid\+Sans:400,700'
+
+      context "when the font name includes an underscore" do
+        it "should convert the underscore to a +" do
+          validate google_webfonts_link_tag(:droid_sans => [400, 700]), 'Droid\+Sans:400,700'
+        end
       end
-    end
-    
-    context "with a combination of all acceptable values" do
-      it "should validate" do
-        validate google_webfonts_link_tag(
-          :font1, "font2", :font_3, "Font 4",
-          :font_5   => 100,
-          "font_6"  => [200, 300]
-        ), 'Font1|Font2|Font\+3|Font\+4|Font\+5:100|Font\+6:200,300'
+
+      context "when the font name includes a space" do
+        it "should conver the space to a +" do
+          validate google_webfonts_link_tag("Droid Sans" => [400, 700]), 'Droid\+Sans:400,700'
+        end
+      end
+
+      context "with a combination of all acceptable values" do
+        it "should validate" do
+          validate google_webfonts_link_tag(
+               :font1, "font2", :font_3, "Font 4",
+               :font_5   => 100,
+               "font_6"  => [200, 300]
+           ), 'Font1|Font2|Font\+3|Font\+4|Font\+5:100|Font\+6:200,300'
+        end
       end
     end
   end
-  
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
 require 'rubygems'
 require 'sinatra'
+require 'action_view'
+require 'rspec/rails/adapters'
+require 'rspec/rails/example/rails_example_group'
+require 'rspec/rails/example/helper_example_group'
 require "google-webfonts"


### PR DESCRIPTION
The latest merged pull request has syntax error. With the syntax error fixed (per pull request by @bokmann) specs are still broken. I've fixed the broken specs and added one for the case when request.ssl? returns true. =)

Cheers
