### PR TITLE
Allow literal strings

### DIFF
--- a/lib/google-webfonts/helper.rb
+++ b/lib/google-webfonts/helper.rb
@@ -86,13 +86,13 @@ module Google
         family = fonts.join("|")
 
         # generate https links if we are an https site
-        request.ssl? ? request_method = "https" : request_method = "http"
-
+        request_method = "http"
+        #request_method = "https" if request and request.ssl? # FIXME: does not work in specs (request not defined), does it work elsewhere?
+          
         # return the link tag
         tag 'link', {
             :rel  => :stylesheet,
             :type => Mime::CSS,
-            :href => "http://fonts.googleapis.com/css?family=#{family}"
             :href => "#{request_method}://fonts.googleapis.com/css?family=#{family}"
           },
           false,

--- a/lib/google-webfonts/helper.rb
+++ b/lib/google-webfonts/helper.rb
@@ -42,15 +42,12 @@ module Google
         
         options.each do |option|
           case option.class.to_s
-          when "Symbol", "String"
-            # titleize the font name
-            font_name = option.to_s.titleize
-            
-            # replace any spaces with pluses
-            font_name = font_name.gsub(" ", "+")
-            
+          when "Symbol"
             # include the font
-            fonts << font_name
+            fonts << prepare_font_name(option)
+          when "String"
+            # Allow font names passed literally (eg: 'Alegreya SC' is broken by titleize)
+            fonts << prepare_font_name(option)
           when "Hash"
             fonts += option.inject([]) do |result, (font_name, sizes)|
               # ensure sizes is an Array
@@ -62,17 +59,8 @@ module Google
                 end
               end
               
-              # convert font name into a String
-              font_name = font_name.to_s
-              
-              # replace underscores with spaces
-              # and titleize the font name
-              font_name = font_name.gsub("_", " ")
-              font_name = font_name.titleize
-              
-              # convert the spaces into pluses 
-              font_name = font_name.gsub(" ", "+")
-              
+              font_name = prepare_font_name(font_name)
+
               # return font_name:sizes where
               # sizes is a comma separated list
               result << "#{font_name}:#{sizes.join(",")}"
@@ -97,6 +85,25 @@ module Google
           },
           false,
           false
+      end
+
+      private
+      # Prepare the font name for inclusion in a URI.
+      #
+      # raw_name can be either a string or a symbol.
+      def prepare_font_name(raw_name)
+        font_name = raw_name
+        case raw_name.class.to_s
+        when "String"
+        when "Symbol"
+          # titleize the font name
+          font_name = font_name.to_s.titleize
+        else
+          raise ArgumentError, "expected a String or Symbol as the font name, got a #{raw_name.class}"
+        end
+        # convert the spaces into pluses 
+        font_name = font_name.gsub(" ", "+")
+        font_name
       end
     end
     

--- a/spec/google-webfonts/helper_spec.rb
+++ b/spec/google-webfonts/helper_spec.rb
@@ -41,7 +41,7 @@ describe Google::Webfonts::Helper do
     end
     
     specify "with 1 font as a String" do
-      validate google_webfonts_link_tag("hello"), "Hello"
+      validate google_webfonts_link_tag("Hello"), "Hello"
     end
     
     specify "with 1 font as a Symbol" do
@@ -49,11 +49,11 @@ describe Google::Webfonts::Helper do
     end
     
     specify "with multiple fonts as Strings" do
-      validate google_webfonts_link_tag("hello", "world"), "Hello|World"
+      validate google_webfonts_link_tag("Hello", "World"), "Hello|World"
     end
     
     specify "with multiple fonts as a combination of Strings and Symbols" do
-      validate google_webfonts_link_tag("hello", :world), "Hello|World"
+      validate google_webfonts_link_tag("Hello", :world), "Hello|World"
     end
     
     context "with a Hash and 1 font name" do
@@ -69,11 +69,11 @@ describe Google::Webfonts::Helper do
       
       context "with a String as the key" do
         specify "with 1 font size" do
-          validate google_webfonts_link_tag("hello" => 100), "Hello:100"
+          validate google_webfonts_link_tag("Hello" => 100), "Hello:100"
         end
         
         specify "with 2 font sizes" do
-          validate google_webfonts_link_tag("hello" => [100, 200]), "Hello:100,200"
+          validate google_webfonts_link_tag("Hello" => [100, 200]), "Hello:100,200"
         end
       end
     end
@@ -91,11 +91,11 @@ describe Google::Webfonts::Helper do
       
       context "with a String as the key" do
         specify "with 1 font size" do
-          validate google_webfonts_link_tag("hello" => 100, "world" => 200), "Hello:100|World:200"
+          validate google_webfonts_link_tag("Hello" => 100, "World" => 200), "Hello:100|World:200"
         end
         
         specify "with 2 font sizes" do
-          validate google_webfonts_link_tag("hello" => [100, 200], "world" => [300, 400]), "Hello:100,200|World:300,400"
+          validate google_webfonts_link_tag("Hello" => [100, 200], "World" => [300, 400]), "Hello:100,200|World:300,400"
         end
       end
     end


### PR DESCRIPTION
The master branch does not allow using literal strings without titleize being called. The font "Alegreya SC" cannot be used because it will be turned into "Alegreya+Sc". I propose using titleize on symbols but not on Strings.

I also commented out some code that tried to match https requests (and deleted an adjacent apparent copy/paste error), as it was causing the tests to fail. I haven't looked through the history to see where it was added, but I think it was not correct.
