### PR TITLE
Update link_tag.rb

### DIFF
--- a/google-webfonts.gemspec
+++ b/google-webfonts.gemspec
@@ -4,10 +4,10 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'google-webfonts/version'
 
 Gem::Specification.new do |spec|
-  spec.name = "google-webfonts"
+  spec.name = "GoogleWebfonts"
   spec.version = Google::Webfonts::VERSION
-  spec.authors = ["Travis Haynes"]
-  spec.email = ["travis.j.haynes@gmail.com"]
+  spec.authors = ["Travis Haynes", "Evgeniy Kulikov"]
+  spec.email = ["travis.j.haynes@gmail.com", "im@kulikov.im"]
 
   spec.summary = "Provides a helper for using Google Webfonts in Rails or " +
                  "Sinatra, although it can be used outside of those " +
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.description = "Google Webfonts helper for Rails or Sinatra applications."
 
-  spec.homepage = "https://github.com/travishaynes/Google-Webfonts-Helper"
+  spec.homepage = "https://github.com/im-kulikov/Google-Webfonts-Helper"
   spec.files = `git ls-files -z`.split("\x0")
   spec.executables = spec.files.grep(%r{^bin/}) {|f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^test/})

--- a/lib/google-webfonts/link_tag.rb
+++ b/lib/google-webfonts/link_tag.rb
@@ -44,7 +44,7 @@ module Google
 
       def link_options
         { rel: 'stylesheet',
-          type: Mime[:css],
+          type: type_css,
           href: uri.to_s }
       end
 
@@ -63,6 +63,16 @@ module Google
           q['subset'] = @subsets.join(",") if @subsets.any?
         }.to_query
       end
+      
+      private
+
+        def type_css
+          if ActionPack::VERSION::MAJOR < 5
+            return Mime::CSS
+          end
+
+          return Mime[:css]
+        end
     end
   end
 end

--- a/lib/google-webfonts/link_tag.rb
+++ b/lib/google-webfonts/link_tag.rb
@@ -44,7 +44,7 @@ module Google
 
       def link_options
         { rel: 'stylesheet',
-          type: Mime::CSS,
+          type: Mime[:css],
           href: uri.to_s }
       end
 

--- a/lib/google-webfonts/version.rb
+++ b/lib/google-webfonts/version.rb
@@ -1,6 +1,6 @@
 module Google
   module Webfonts
     # Public: Current version of the gem
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
FIX: DEPRECATION WARNING: Accessing mime types via constants is deprecated. Please change `Mime::CSS` to `Mime[:css]`

https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/mime_type.rb#L53
https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/mime_type.rb#L66
